### PR TITLE
fix: prevent DataTables TN/7 Ajax errors on table re-initialization

### DIFF
--- a/R/modules/bin_analysis/mod_bin_analysis_server.R
+++ b/R/modules/bin_analysis/mod_bin_analysis_server.R
@@ -124,14 +124,14 @@ mod_bin_analysis_server <- function(id, state, processor, logger) {
     output$bin_content_table <- renderDT({
       req(!is.null(analysis_results()))
       results <- analysis_results()
+      # Guard: req() here prevents DataTables receiving an empty/null Ajax
+      # response (which triggers TN/7) when content isn't ready yet.
+      req(!is.null(results$content))
 
       # Ensure required columns exist
       required_cols <- c("bin_uri", "total_records", "unique_species", "species_list", "countries", "concordance")
-
-      if(!is.null(results$content)) {
-        content_data <- results$content[, intersect(names(results$content), required_cols)]
-        format_bin_content_table(content_data)
-      }
+      content_data <- results$content[, intersect(names(results$content), required_cols)]
+      format_bin_content_table(content_data)
     })
 
     # Summary box outputs with enhanced metrics

--- a/R/modules/specimen_handling/mod_specimen_handling_server.R
+++ b/R/modules/specimen_handling/mod_specimen_handling_server.R
@@ -25,21 +25,25 @@ mod_specimen_handling_server <- function(id, state, processor, logger) {
     # Proxy for updating specimen table in-place when annotations change
     specimen_proxy <- DT::dataTableProxy("specimen_table")
 
-    # Watch for annotation changes AND data changes, then refresh the
-    # specimen table via replaceData().  rv$filtered_data is reactive
-    # (not isolated) so this fires on both annotation edits AND
-    # filter/tab-switch changes — fixing the stale-data-on-tab-switch bug.
+    # Watch for annotation changes, then refresh the specimen table via
+    # replaceData().  rv$filtered_data is read with isolate() so this observer
+    # only fires when annotations change — NOT when the underlying data
+    # changes.  Data changes are handled exclusively by renderDT below,
+    # which avoids a race condition where replaceData() and renderDT both
+    # fire simultaneously on the same reactive invalidation, causing
+    # DataTables to receive an Ajax error (TN/7) mid-initialization.
     observe({
       store <- state$get_store()
 
-      # Reactive dependencies: annotation keys
+      # Reactive dependencies: annotation keys only
       current_selections <- store$selected_specimens
       current_flags      <- store$specimen_flags
       current_notes      <- store$specimen_curator_notes
       current_uids       <- store$specimen_updated_ids
 
-      # Reactive dependency: filtered data (NOT isolated)
-      data <- rv$filtered_data
+      # Read filtered data WITHOUT creating a reactive dependency; renderDT
+      # handles the re-render when rv$filtered_data itself changes.
+      data <- isolate(rv$filtered_data)
       if (is.null(data) || nrow(data) == 0) return()
 
       prepared <- prepare_module_data(


### PR DESCRIPTION
Two race conditions were triggering the DataTables Ajax error (TN/7):

1. In mod_specimen_handling_server.R: the replaceData() observer and renderDT() both depended on rv$filtered_data, so when data changed both fired simultaneously. renderDT destroys/recreates the DataTable while replaceData tries to update it, leaving DataTables mid-Ajax with no valid response. Fixed by reading rv$filtered_data with isolate() in the replaceData observer, so it only fires on annotation changes (flags, notes, selections); renderDT exclusively handles data changes.

2. In mod_bin_analysis_server.R: renderDT returned NULL implicitly when results$content was NULL (via an if-without-else), causing DataTables to receive an empty Ajax response. Fixed by using req() to suspend the output until content is available.

https://claude.ai/code/session_01T7iR8M4tP7H1FMZwwXdWTs